### PR TITLE
chore: sync rhiza template v0.10.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         exclude: ^recipe/meta\.yaml$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.15.10'
+    rev: 'v0.15.11'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 99200fb7552dd051c5c672b476f85c277498a7ab
+sha: ea7baa29f491ef74b76882bd75c1ae0551ccad0d
 repo: jebel-quant/rhiza
 host: github
-ref: v0.10.1
+ref: v0.10.2
 include: []
 exclude: []
 templates:
@@ -17,7 +17,6 @@ files:
 - .github/actions/configure-git-auth/action.yml
 - .github/dependabot.yml
 - .github/secret_scanning.yml
-- .github/semgrep.yml
 - .github/workflows/rhiza_book.yml
 - .github/workflows/rhiza_marimo.yml
 - .github/workflows/rhiza_release.yml
@@ -48,5 +47,5 @@ files:
 - docs/index.md
 - docs/mkdocs-base.yml
 - ruff.toml
-synced_at: '2026-04-18T15:57:29Z'
+synced_at: '2026-04-22T04:19:29Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 template-repository: "jebel-quant/rhiza"
-template-branch: "v0.10.1"
+template-branch: "v0.10.2"
 
 templates:
   - github

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 ## Makefile (repo-owned)
 # Keep this file small. It can be edited without breaking template sync.
 
-DEFAULT_AI_MODEL=claude-sonnet-4.6
 LOGO_FILE=.rhiza/assets/rhiza-logo.svg
 
 # Override template default: fix quoting bug and typo (mkdocstring -> mkdocstrings)

--- a/docs/mkdocs-base.yml
+++ b/docs/mkdocs-base.yml
@@ -55,11 +55,11 @@ theme:
   palette:
     - scheme: default
       toggle:
-        icon: material/brightness-7
+        icon: material/weather-sunny
         name: Switch to dark mode
     - scheme: slate
       toggle:
-        icon: material/brightness-4
+        icon: material/weather-night
         name: Switch to light mode
 
 # ----------------------------------------------------------------------------
@@ -108,3 +108,13 @@ markdown_extensions:
 # ----------------------------------------------------------------------------
 plugins:
   - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+


### PR DESCRIPTION
## Summary

- Update rhiza template version from `v0.10.1` to `v0.10.2` in `.rhiza/template.yml`
- Run `make sync` to apply upstream template changes

## Changes from sync

- `.pre-commit-config.yaml`: bump ruff from `v0.15.10` → `v0.15.11`
- `docs/mkdocs-base.yml`: update theme toggle icons (`brightness-7/4` → `weather-sunny/night`) and add `mkdocstrings` plugin config
- `.rhiza/template.lock`: update SHA and ref to `v0.10.2`, remove orphaned `.github/semgrep.yml` entry

## Test plan

- [ ] CI passes
- [ ] No merge conflicts (sync applied cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tool versions and build configuration.

* **Documentation**
  * Enhanced documentation theme styling with improved icon assets and enabled automatic Python docstring generation for better code documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->